### PR TITLE
chore: add jsbi benchmarks

### DIFF
--- a/benchmark/big-number.js
+++ b/benchmark/big-number.js
@@ -4,6 +4,7 @@ const {
 const BigNumberJS = require('bignumber.js')
 const BigJS = require('bignumber.js')
 const BigNumber2 = require('big-number')
+const JSBI = require("jsbi");
 
 exports['native'] = () => BigInt('1111222233334444555566')
 
@@ -14,3 +15,5 @@ exports['bignumber.js'] = () => new BigNumberJS('1111222233334444555566')
 exports['big.js'] = () => new BigJS('1111222233334444555566')
 
 exports['big-number'] = () => new BigNumber2('1111222233334444555566')
+
+exports["jsbi"] = () => JSBI.BigInt("1111222233334444555566");

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "hyperid": "^2.0.2",
         "jest": "^25.0.0",
         "jest-extended": "^0.11.2",
+        "jsbi": "^3.1.1",
         "lint-staged": "^10.0.0",
         "lodash": "^4.17.15",
         "pluralize": "^8.0.0",


### PR DESCRIPTION
Show performance discrepancy between native bigint and jsbi https://github.com/ArkEcosystem/utils/issues/60