### PR TITLE
chore: make type fest a non-dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
         "deepmerge": "^4.2.2",
         "fast-copy": "^2.0.4",
         "fast-deep-equal": "^3.1.1",
-        "fast-sort": "^2.0.0"
+        "fast-sort": "^2.0.0",
+        "type-fest": "^0.9.0"
     },
     "devDependencies": {
         "@arkecosystem/commitlint": "^0.1.0",
@@ -72,7 +73,6 @@
         "prettier": "^1.19.1",
         "random-object": "^1.3.4",
         "ts-jest": "^25.0.0",
-        "type-fest": "^0.9.0",
         "typescript": "^3.7.3"
     },
     "engines": {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adding `utils` as a dependency resulted in an error with not being able to find the `type-fest` dependency.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
